### PR TITLE
Issue1 solved, now support Sinograms and Latin alphabet

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html lang="en">
 <head>
-    <meta charset="UTF-8 UTF-16">
+    <meta charset="UTF-8">
     <meta http-equiv="X-UA-Compatible" content="IE=edge">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     <link rel="stylesheet" href="./css/styles.css">


### PR DESCRIPTION
This issue was solved by removing the UTF-16 meta support, due to the fact that UTF-8 has broad support for alphabets and syllabaries.